### PR TITLE
fix(calendar): auto-run migrations on cold start (closes #13-#16)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,34 @@
+/**
+ * Next.js instrumentation hook — runs once per server cold start, before
+ * any request is handled.
+ *
+ * We use it to auto-run database migrations on each fresh container. The
+ * migrations in src/lib/db/migrate.ts are fully idempotent (every CREATE /
+ * ALTER uses IF NOT EXISTS or DO-block guards), so re-running them on
+ * every cold start is free.
+ *
+ * Why this exists: previously, schema changes required a manual
+ *   curl -X POST .../api/db-migrate -H "Authorization: Bearer $CRON_SECRET"
+ * after every deploy. Forgetting that step left production with a stale
+ * schema, which manifested as a cascade of 401s when `db.select().from(members)`
+ * referenced a column that hadn't been added yet. See
+ * gotcha_calendar_bootstrap_schema_drift.md.
+ *
+ * Skip with SKIP_BOOT_MIGRATE=true (e.g. for local dev when iterating on a
+ * dev DB, or for a deploy that must not touch the schema).
+ */
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
+  if (process.env.SKIP_BOOT_MIGRATE === 'true') return;
+
+  const { runMigrations } = await import('@/lib/db/migrate');
+  try {
+    const result = await runMigrations();
+    console.warn('[boot-migrate]', JSON.stringify(result));
+  } catch (err) {
+    console.error(
+      '[boot-migrate] failed:',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/instrumentation.ts` that runs `runMigrations()` once per Node.js cold start, before any request is handled.
- Restores #13/#14/#15/#16: the `members.nudged_at` column added in fd82cda was never applied to prod (migrate.ts only runs via manual `curl /api/db-migrate`). `db.select().from(members)` in `getCurrentMember` errored on the missing column, returned null, and cascaded into 401s across `/api/profile`, `/api/notifications`, `/api/calendar/feed-token`, and the `/book` redirect loop. Bug-report kept working because it only projects `id`.
- Idempotent: every CREATE/ALTER in `migrate.ts` uses IF NOT EXISTS. Re-running per cold start is free.

## Test plan
- [x] typecheck passes (`tsc --noEmit`)
- [ ] Deploy: confirm `[boot-migrate]` log line appears in Vercel function logs on first invocation
- [ ] Verify `/api/profile` returns 200 (or proper 401 for unauthed) instead of erroring out for users m#128 / m#6938
- [ ] Verify `/book` no longer loops to `/welcome` for signed-in members

Closes #13 #14 #15 #16