### PR TITLE
fix(calendar): split instrumentation hook for Edge-safe build

### DIFF
--- a/src/instrumentation-node.ts
+++ b/src/instrumentation-node.ts
@@ -1,0 +1,33 @@
+/**
+ * Node-only side of the instrumentation hook. Loaded from instrumentation.ts
+ * inside a `NEXT_RUNTIME === 'nodejs'` branch so its `postgres` (tls/net/crypto)
+ * imports never reach the Edge bundle.
+ *
+ * Auto-runs database migrations on every cold start. migrate.ts is fully
+ * idempotent (every CREATE / ALTER uses IF NOT EXISTS or DO-block guards),
+ * so re-running on every cold start is free.
+ *
+ * Why this exists: previously, schema changes required a manual
+ *   curl -X POST .../api/db-migrate -H "Authorization: Bearer $CRON_SECRET"
+ * after every deploy. Forgetting that step left production with a stale
+ * schema, which manifested as a cascade of 401s when `db.select().from(members)`
+ * referenced a column that hadn't been added yet. See
+ * gotcha_calendar_bootstrap_schema_drift.md.
+ *
+ * Skip with SKIP_BOOT_MIGRATE=true (e.g. for local dev when iterating on a
+ * dev DB, or for a deploy that must not touch the schema).
+ */
+import { runMigrations } from '@/lib/db/migrate';
+
+if (process.env.SKIP_BOOT_MIGRATE !== 'true') {
+  runMigrations()
+    .then((result) => {
+      console.warn('[boot-migrate]', JSON.stringify(result));
+    })
+    .catch((err) => {
+      console.error(
+        '[boot-migrate] failed:',
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,33 +2,15 @@
  * Next.js instrumentation hook — runs once per server cold start, before
  * any request is handled.
  *
- * We use it to auto-run database migrations on each fresh container. The
- * migrations in src/lib/db/migrate.ts are fully idempotent (every CREATE /
- * ALTER uses IF NOT EXISTS or DO-block guards), so re-running them on
- * every cold start is free.
- *
- * Why this exists: previously, schema changes required a manual
- *   curl -X POST .../api/db-migrate -H "Authorization: Bearer $CRON_SECRET"
- * after every deploy. Forgetting that step left production with a stale
- * schema, which manifested as a cascade of 401s when `db.select().from(members)`
- * referenced a column that hadn't been added yet. See
- * gotcha_calendar_bootstrap_schema_drift.md.
- *
- * Skip with SKIP_BOOT_MIGRATE=true (e.g. for local dev when iterating on a
- * dev DB, or for a deploy that must not touch the schema).
+ * This top-level file MUST stay edge-safe: Next bundles it for every runtime
+ * the app targets, and the Edge runtime can't resolve `tls`/`net`/`crypto`
+ * (which `postgres` and our migrate logic pull in). The runtime-specific
+ * work lives in `./instrumentation-node.ts`, loaded only when
+ * `NEXT_RUNTIME === 'nodejs'` so webpack can prune the import from the
+ * Edge bundle.
  */
 export async function register() {
-  if (process.env.NEXT_RUNTIME !== 'nodejs') return;
-  if (process.env.SKIP_BOOT_MIGRATE === 'true') return;
-
-  const { runMigrations } = await import('@/lib/db/migrate');
-  try {
-    const result = await runMigrations();
-    console.warn('[boot-migrate]', JSON.stringify(result));
-  } catch (err) {
-    console.error(
-      '[boot-migrate] failed:',
-      err instanceof Error ? err.message : String(err),
-    );
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('./instrumentation-node');
   }
 }


### PR DESCRIPTION
Followup to #19 (which failed Vercel build). Top-level `instrumentation.ts` must be edge-safe; the postgres-touching code now lives in `instrumentation-node.ts`, loaded only inside `NEXT_RUNTIME === 'nodejs'` branch so webpack prunes it from the Edge bundle. `npm run build` verified locally.